### PR TITLE
Pre-integration test build

### DIFF
--- a/.github/workflows/test-build-page.yml
+++ b/.github/workflows/test-build-page.yml
@@ -1,0 +1,22 @@
+name: Pre-Integration Test Build
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+
+      - name: Test Build Webpage
+        uses: actions/jekyll-build-pages@v1.0.7


### PR DESCRIPTION
To ensure, that the webpage can be built after PR changes - a pre-integration test build is added.